### PR TITLE
[fix] 記事の excerpt が meta description に反映されるよう修正

### DIFF
--- a/src/pages/posts/[slug].tsx
+++ b/src/pages/posts/[slug].tsx
@@ -23,6 +23,7 @@ export async function getStaticProps({ params }: Params) {
     'content',
     'ogImage',
     'coverImage',
+    'excerpt',
     'tags',
   ]);
   const content = await markdownToHtml(post.content || '');


### PR DESCRIPTION
ブログテンプレート使わせて頂いております。素敵なテンプレートを公開して頂き、ありがとうございます🙇

## 概要

記事のマークダウンファイルの `excerpt` が、記事ページの `<meta name="description">` および `<meta property="og:description" >` の情報に反映されていなかったため、反映されるように修正しました。

## その他

`src/pages/posts/[slug].tsx` の `getStaticProps` を修正しておりますが、もし意図と違った修正になっておりましたら申し訳ございません。
ご検討のほど何卒よろしくお願い致します。